### PR TITLE
Make "Aud" an array to support "cross-client trust" - scenario

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,15 +51,15 @@ type app struct {
 }
 
 type claim struct {
-	Iss           string `json:"iss"`
-	Sub           string `json:"sub"`
-	Aud           string `json:"aud"`
-	Exp           int    `json:"exp"`
-	Iat           int    `json:"iat"`
-	AtHash        string `json:"at_hash"`
-	Email         string `json:"email"`
-	EmailVerified bool   `json:"email_verified"`
-	Name          string `json:"name"`
+	Iss           string   `json:"iss"`
+	Sub           string   `json:"sub"`
+	Aud           []string `json:"aud"`
+	Exp           int      `json:"exp"`
+	Iat           int      `json:"iat"`
+	AtHash        string   `json:"at_hash"`
+	Email         string   `json:"email"`
+	EmailVerified bool     `json:"email_verified"`
+	Name          string   `json:"name"`
 }
 
 // return an HTTP client which trusts the provided root CAs.

--- a/main.go
+++ b/main.go
@@ -51,15 +51,15 @@ type app struct {
 }
 
 type claim struct {
-	Iss           string   `json:"iss"`
-	Sub           string   `json:"sub"`
-	Aud           []string `json:"aud"`
-	Exp           int      `json:"exp"`
-	Iat           int      `json:"iat"`
-	AtHash        string   `json:"at_hash"`
-	Email         string   `json:"email"`
-	EmailVerified bool     `json:"email_verified"`
-	Name          string   `json:"name"`
+	Iss           string      `json:"iss"`
+	Sub           string      `json:"sub"`
+	Aud           interface{} `json:"aud"`
+	Exp           int         `json:"exp"`
+	Iat           int         `json:"iat"`
+	AtHash        string      `json:"at_hash"`
+	Email         string      `json:"email"`
+	EmailVerified bool        `json:"email_verified"`
+	Name          string      `json:"name"`
 }
 
 // return an HTTP client which trusts the provided root CAs.


### PR DESCRIPTION
The code works in your scenario, but "in the general case, the aud value is an array of case sensitive strings." (https://openid.net/specs/openid-connect-core-1_0.html#IDToken)

If one specifies "cross-client trust" (https://github.com/dexidp/dex/blob/master/Documentation/custom-scopes-claims-clients.md#cross-client-trust-and-authorized-party  - I think the example in the Dex-Doc where the "ID token claims" are shown is not correct any more), an array is returned for "Aud" (due to https://github.com/dexidp/dex/pull/1088).

To support both possible "aud"-variants, single string and string array, we have to use interface{} and decide on the concrete response-value via type assert if needed.